### PR TITLE
Coach delete availability

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -39,6 +39,12 @@ class UserController < ApplicationController
     redirect_to availabilities_path
   end
 
+  def delete_availabilities
+    CoachAvailability.delete(params[:id])
+    redirect_to availabilities_path
+    return
+  end
+
   def member_profile
     # For testing purposes below
     # if !(:current_user.blank?)

--- a/app/models/coach_availability.rb
+++ b/app/models/coach_availability.rb
@@ -18,6 +18,7 @@ class CoachAvailability < ApplicationRecord
         other_avail.each do |a|
             a_st_time = a.start_time.hour + sec_to_hour(a.start_time.sec)
             a_et_time = a.end_time.hour + sec_to_hour(a.end_time.sec)
+            #bug fix here
             if (new_st_time...new_et_time).overlaps?(a.start_time.hour...a.end_time.hour)
                 valid = false
             end

--- a/app/views/user/availabilities.html.erb
+++ b/app/views/user/availabilities.html.erb
@@ -5,7 +5,7 @@
 <h2> Current Availabilities </h2>
 
 <table class="table table-hover">
-  <tbody>
+  <tbody >
     <% if @time_table.empty? %>
       <h3> No Availabilities Found </h3>
     <% end %>
@@ -13,6 +13,9 @@
       <tr>
         <td><%= record.day%></td>
         <td><%= record.start_time.strftime("%l:%M%p")%> - <%= record.end_time.strftime("%l:%M%p") %> </td>
+        <td> <%= form_for :user, url: "/users/profile/availabilities/#{record.id}", method: 'delete' do |f| %>
+          <%= f.submit 'Delete', id: record.id.to_s + '_delete' %>
+        <% end %> </td>
       </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,10 @@ Rails.application.routes.draw do
   
   get 'user/booking' => 'user#booking', :as => 'booking'
 
+  # availabilities routes
   get 'users/profile/availabilities' => 'user#availabilities', :as =>'availabilities'
   post 'users/profile/availabilities' => 'user#add_availabilities', :as =>'add_availabilities'
+  delete 'users/profile/availabilities/:id' => 'user#delete_availabilities', :as =>'delete_availabilities'
 
   root to: "home#index"
   # This needs to be at the end

--- a/features/delete_availability.feature
+++ b/features/delete_availability.feature
@@ -11,6 +11,7 @@ Background: Users in the Database
 And the following availabilities exist:
   | coach_id     | day      | start_time    | end_time  |
   | 6            | Sunday   | 9am           | 12pm      |
+  | 6            | Monday   | 12pm           | 3pm      |
   | 6            | Sunday   | 12pm          | 3pm       |
   | 6            | Sunday   | 3pm           | 6pm       |
 
@@ -19,6 +20,17 @@ Scenario: Delete availibility
   Given "Pizza" is a "Coach"
   And "Pizza" logs in with correct credentials with password "12345678"
   And "Pizza" goes to "Availabilities Page"
+  Then I should see "9:00AM - 12:00PM"
   And I press "1_delete"
   Then I should not see "9:00AM - 12:00PM"
   But I should see "12:00PM - 3:00PM"
+
+Scenario: Delete availibility with a day that has the same time
+  Given "Pizza" is a "Coach"
+  And "Pizza" logs in with correct credentials with password "12345678"
+  And "Pizza" goes to "Availabilities Page"
+  Then I should see "12:00PM - 3:00PM"
+  And I press "2_delete"
+  Then I should  see "12:00PM - 3:00PM"
+  And I press "2_delete"
+  But I should not see "12:00PM - 3:00PM"

--- a/features/delete_availability.feature
+++ b/features/delete_availability.feature
@@ -31,6 +31,6 @@ Scenario: Delete availibility with a day that has the same time
   And "Pizza" goes to "Availabilities Page"
   Then I should see "12:00PM - 3:00PM"
   And I press "2_delete"
-  Then I should  see "12:00PM - 3:00PM"
-  And I press "2_delete"
+  Then I should see "12:00PM - 3:00PM"
+  And I press "3_delete"
   But I should not see "12:00PM - 3:00PM"

--- a/features/delete_availability.feature
+++ b/features/delete_availability.feature
@@ -1,0 +1,24 @@
+Feature: Delete availability as a coach
+ 
+  As an coach using this app
+  So that I can coach club members
+  I want delete availabilities
+
+Background: Users in the Database
+ Given the following users exist:
+  | id | name            | email                    | password | membership    |
+  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Coach         |
+And the following availabilities exist:
+  | coach_id     | day      | start_time    | end_time  |
+  | 6            | Sunday   | 9am           | 12pm      |
+  | 6            | Sunday   | 12pm          | 3pm       |
+  | 6            | Sunday   | 3pm           | 6pm       |
+
+
+Scenario: Delete availibility
+  Given "Pizza" is a "Coach"
+  And "Pizza" logs in with correct credentials with password "12345678"
+  And "Pizza" goes to "Availabilities Page"
+  And I press "1_delete"
+  Then I should not see "9:00AM - 12:00PM"
+  But I should see "12:00PM - 3:00PM"


### PR DESCRIPTION
Adds feature that allows coaches to delete availability from their list of availability by adding a simple delete button in the last column of every availability row. This can be found by going to the "My profile page" -> "Edit availability"