### PR TITLE
Manager update user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,13 @@ class User < ApplicationRecord
     statuses_blank = statuses.map{|c| [c, c]}.prepend(['Select...', nil])
     return statuses_blank
   end
+
+  def self.manager_update_membership_to(curr_user)
+    statuses = ['Club Member', 'Coach']
+    statuses.delete(curr_user.membership)
+    statuses_blank = statuses.map{|c| [c, c]}.prepend(['Select...', nil])
+    return statuses_blank
+  end
       
   def self.coaches
     return User.select(:id, :email, :name).where(:membership => ["Coach"])

--- a/app/views/user/administrator_profile.html.erb
+++ b/app/views/user/administrator_profile.html.erb
@@ -9,7 +9,7 @@
       <th>Membership Status</th>
       <th>Change Status</th>
     </tr>
-  </thead>
+</thead>
 <% @users.each do |user| %>                    
     <tr>
       <td class="name"><%= user.name%></td>

--- a/app/views/user/manager_profile.html.erb
+++ b/app/views/user/manager_profile.html.erb
@@ -1,15 +1,30 @@
 
-<p> <h5> Membership: <%= @membership %></h5>
+<p> <h5 style="text-align:center;"> <%= @name %> | <%= @membership %></h5>
+
 <table class="table table-hover">
+<thead>
+    <tr>
+      <th>Name</th>
+      <th>Email</th>
+      <th>Membership Status</th>
+      <th>Change Status</th>
+    </tr>
+</thead>
 <% @users.each do |user| %>                    
     <tr>
-      <td><%= user.name%><td>
-      <td><%= user.email%></td>
-      <td><%= user.membership %></td>
+      <td class="name"><%= user.name%></td>
+      <td class="email"><%= user.email%></td>
+      <td class="membership"><%= user.membership %></td>
+      <td>
+      <%= form_for :user, :namespace => user.name, :url => '/user/profile/update_other', :html => { :method => 'post'} do |f| %>
+        <%= f.select(:membership, User.manager_update_membership_to(user), {disabled: '', selected: '', required: true})  %>
+        <%= hidden_field_tag(:id, user.id) %>
+        <%= f.button 'Update', value: user.name+'_update', class: 'button', type: 'submit' %>
+      <% end %>
+      </td>
     </tr>
 <% end %>
 </table>
-
 
 <br> <%= link_to "Logout", destroy_user_session_path, method: :delete, :class => 'navbar-link'  %>
 </p>

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -20,7 +20,7 @@ Scenario: log in as a Manager
   Given "John Doe" is a "Manager"
   And "John Doe" logs in with correct credentials with password "12345678"
   Then "John Doe" goes to "My Profile Page" 
-  And he should see membership as "Membership: Manager"
+  And he should see membership as "John Doe | Manager"
 
 Scenario: log in as a Club Member
   Given "Joe Chen" is a "Club Member"

--- a/features/manager_elevate.feature
+++ b/features/manager_elevate.feature
@@ -1,0 +1,30 @@
+Feature: (D)elevate other users as Manager
+ 
+    As a manager
+    I want to see the correct membership statuses
+    So that I can validly (d)elevate users to other membership statuses
+
+Background: Users in the Database
+
+ Given the following users exist:
+  | name            | email                    | password | membership    |
+  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   |
+  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator |
+  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         |
+  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       |
+
+And I go to Login page
+
+# Note that I need to specify passwords here because the authentication process won't let me access user password 
+# All scenarios begin assuming no user is logged in yet
+Scenario: Update Membership as manager (elevate)
+  Given "Matthew Sie" logs in with correct password "dabaka22" and goes to profile page
+  And selects status "Coach" for "Joe Chen"
+  When I press "Joe Chen_update"
+  Then he should see membership status "Coach" for "Joe Chen"
+
+Scenario: Update Membership as manager (delevate)
+  Given "Matthew Sie" logs in with correct password "dabaka22" and goes to profile page
+  And selects status "Club Member" for "Roger Destroyer"
+  When I press "Roger Destroyer_update"
+  Then he should see membership status "Club Member" for "Roger Destroyer"


### PR DESCRIPTION
Feature allowing any managers to update other users' membership statuses between "Coach" and "Club Member". Similar to "Admin elevate user membership" feature, but not as much power/ability to change statuses.