### PR TITLE
Membership history log

### DIFF
--- a/app/assets/javascripts/membership_history.coffee
+++ b/app/assets/javascripts/membership_history.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/membership_history.scss
+++ b/app/assets/stylesheets/membership_history.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the membership_history controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/membership_history_controller.rb
+++ b/app/controllers/membership_history_controller.rb
@@ -1,3 +1,9 @@
 class MembershipHistoryController < ApplicationController
-    
+    def membership_history
+        if current_user.membership == "Administrator"
+          @histories = MembershipHistory.all
+        else
+          redirect_to '/user/profile'
+        end
+    end
 end

--- a/app/controllers/membership_history_controller.rb
+++ b/app/controllers/membership_history_controller.rb
@@ -1,0 +1,3 @@
+class MembershipHistoryController < ApplicationController
+    
+end

--- a/app/controllers/membership_history_controller.rb
+++ b/app/controllers/membership_history_controller.rb
@@ -1,7 +1,7 @@
 class MembershipHistoryController < ApplicationController
     def membership_history
         if current_user.membership == "Administrator"
-          @histories = MembershipHistory.all
+          @histories = MembershipHistory.order(created_at: :desc)
         else
           redirect_to '/user/profile'
         end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -3,8 +3,10 @@ class UserController < ApplicationController
 
   def update_other
     @other = User.find(params[:id])
+    old_membership = @other.membership
     if !params[:user].blank?
       @other.update_attributes(params.require(:user).permit(:membership))
+      Membership_History.create(@other.id, current_user.id, old_membership, @other.membership)
     end
     redirect_to '/user/profile'
   end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -6,7 +6,8 @@ class UserController < ApplicationController
     old_membership = @other.membership
     if !params[:user].blank?
       @other.update_attributes(params.require(:user).permit(:membership))
-      Membership_History.create(@other.id, current_user.id, old_membership, @other.membership)
+      MembershipHistory.create(:user_changed_id => @other.id, :changed_by_id => current_user.id, 
+        :old_membership => old_membership, :new_membership => @other.membership)
     end
     redirect_to '/user/profile'
   end

--- a/app/helpers/membership_history_helper.rb
+++ b/app/helpers/membership_history_helper.rb
@@ -1,0 +1,2 @@
+module MembershipHistoryHelper
+end

--- a/app/models/membership_history.rb
+++ b/app/models/membership_history.rb
@@ -1,0 +1,2 @@
+class MembershipHistory < ApplicationRecord
+end

--- a/app/models/membership_history.rb
+++ b/app/models/membership_history.rb
@@ -1,2 +1,11 @@
 class MembershipHistory < ApplicationRecord
+    def user_changed_name
+        user_changed = User.find(self.user_changed_id)
+        return user_changed.name
+    end
+
+    def changed_by_name
+        changed_by = User.find(self.changed_by_id)
+        return changed_by.name
+    end
 end

--- a/app/views/membership_history/membership_history.html.erb
+++ b/app/views/membership_history/membership_history.html.erb
@@ -13,10 +13,10 @@
   <tbody >
     <% @histories.each do |record| %>
       <tr>
-        <td><%= record.user_changed_name%></td>
-        <td><%= record.old_membership%></td>
-        <td><%= record.new_membership%></td>
-        <td><%= record.changed_by_name%></td>
+        <td class="changed_name"><%= record.user_changed_name%></td>
+        <td class="old"><%= record.old_membership%></td>
+        <td class="new"><%= record.new_membership%></td>
+        <td class="changed_by_name"><%= record.changed_by_name%></td>
         <td><%= record.created_at.in_time_zone("Pacific Time (US & Canada)").strftime("%B %d, %Y %I:%M:%S %p %Z")%></td>
       </tr>
     <% end %>

--- a/app/views/membership_history/membership_history.html.erb
+++ b/app/views/membership_history/membership_history.html.erb
@@ -22,3 +22,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= link_to "Back", :back %>

--- a/app/views/membership_history/membership_history.html.erb
+++ b/app/views/membership_history/membership_history.html.erb
@@ -1,0 +1,24 @@
+<h3 style="text-align:center;"> User Membership Change Log </h3>
+
+<table class="table table-hover">
+<thead>
+    <tr>
+      <th>User Updated</th>
+      <th>Old Membership</th>
+      <th>New Membership</th>
+      <th>Changed By</th>
+      <th>Date/Time Updated</th>
+    </tr>
+</thead>
+  <tbody >
+    <% @histories.each do |record| %>
+      <tr>
+        <td><%= record.user_changed_name%></td>
+        <td><%= record.old_membership%></td>
+        <td><%= record.new_membership%></td>
+        <td><%= record.changed_by_name%></td>
+        <td><%= record.created_at.in_time_zone("Pacific Time (US & Canada)").strftime("%B %d, %Y %I:%M:%S %p %Z")%></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/user/administrator_profile.html.erb
+++ b/app/views/user/administrator_profile.html.erb
@@ -26,6 +26,7 @@
 <% end %>
 </table>
 
+<br> <%= link_to "User Membership Change Log", membership_history_path, method: :get, :class => 'navbar-link'  %>
 <br> <%= link_to "Logout", destroy_user_session_path, method: :delete, :class => 'navbar-link'  %>
 </p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,11 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get 'user/profile' => 'user#member_profile', :as => 'member_profile'
  
+  # Route when an admin or manager submits form to update a user's membership status
   post 'user/profile/update_other' => 'user#update_other', :as => 'update_other'
+
+  # Route for admin to view change log of all membership status changes
+  get 'user/profile/membership_history' => 'membership_history#membership_history', :as => 'membership_history'
   
   get 'user/booking' => 'user#booking', :as => 'booking'
 

--- a/db/migrate/20190415204348_create_membership_histories.rb
+++ b/db/migrate/20190415204348_create_membership_histories.rb
@@ -1,0 +1,11 @@
+class CreateMembershipHistories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :membership_histories do |t|
+      t.integer :user_changed_id, null:false
+      t.integer :changed_by_id, null:false
+      t.string  :old_membership, null:false
+      t.string  :new_membership, null:false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_09_211313) do
+ActiveRecord::Schema.define(version: 2019_04_15_204348) do
 
   create_table "coach_availabilities", force: :cascade do |t|
     t.integer "coach_id", null: false
@@ -18,6 +18,15 @@ ActiveRecord::Schema.define(version: 2019_04_09_211313) do
     t.string "day", null: false
     t.time "start_time", null: false
     t.time "end_time", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "membership_histories", force: :cascade do |t|
+    t.integer "user_changed_id", null: false
+    t.integer "changed_by_id", null: false
+    t.string "old_membership", null: false
+    t.string "new_membership", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/features/manager_elevate.feature
+++ b/features/manager_elevate.feature
@@ -21,10 +21,10 @@ Scenario: Update Membership as manager (elevate)
   Given "Matthew Sie" logs in with correct password "dabaka22" and goes to profile page
   And selects status "Coach" for "Joe Chen"
   When I press "Joe Chen_update"
-  Then he should see membership status "Coach" for "Joe Chen"
+  Then he should see attribute "membership" value "Coach" for "Joe Chen"
 
 Scenario: Update Membership as manager (delevate)
   Given "Matthew Sie" logs in with correct password "dabaka22" and goes to profile page
   And selects status "Club Member" for "Roger Destroyer"
   When I press "Roger Destroyer_update"
-  Then he should see membership status "Club Member" for "Roger Destroyer"
+  Then he should see attribute "membership" value "Club Member" for "Roger Destroyer"

--- a/features/membership_history.feature
+++ b/features/membership_history.feature
@@ -1,8 +1,8 @@
-Feature: (D)elevate other users as Admin
+Feature: Admin can see all membership changes
  
-    As an admin
-    I want to see the correct membership statuses
-    So that I can validly (d)elevate users to other membership statuses
+    As an administrator
+    I want to navigate to a change log
+    So that I see all the membership status changes performed by other admins/managers
 
 Background: Users in the Database
 
@@ -17,14 +17,14 @@ And I go to Login page
 
 # Note that I need to specify passwords here because the authentication process won't let me access user password 
 # All scenarios begin assuming no user is logged in yet
-Scenario: Update Membership as Admin (elevate)
+Scenario: See change log table as admin
   Given "Matthew Sie" logs in with correct password "dabaka22" and goes to profile page
-  And selects status "Manager" for "Joe Chen"
-  When I press "Joe Chen_update"
-  Then he should see attribute "membership" value "Manager" for "Joe Chen"
+  And I follow "User Membership Change Log"
+  Then I should see "User Membership Change Log"
 
-Scenario: Update Membership as Admin (delevate)
+# Using the "admin_elevate_step" for "seeing" correct attributes in table
+Scenario: Update user and see change in log table
   Given "Matthew Sie" logs in with correct password "dabaka22" and goes to profile page
   And selects status "Club Member" for "Roger Destroyer"
   When I press "Roger Destroyer_update"
-  Then he should see attribute "membership" value "Club Member" for "Roger Destroyer"
+  And I follow "User Membership Change Log"

--- a/features/membership_history.feature
+++ b/features/membership_history.feature
@@ -22,9 +22,17 @@ Scenario: See change log table as admin
   And I follow "User Membership Change Log"
   Then I should see "User Membership Change Log"
 
-# Using the "admin_elevate_step" for "seeing" correct attributes in table
-Scenario: Update user and see change in log table
+Scenario: Update user and see change at the top of the log table
   Given "Matthew Sie" logs in with correct password "dabaka22" and goes to profile page
   And selects status "Club Member" for "Roger Destroyer"
   When I press "Roger Destroyer_update"
   And I follow "User Membership Change Log"
+  Then I should see the change of "Roger Destroyer" membership from "Coach" to "Club Member" by "Matthew Sie"
+  And I should see these "Roger Destroyer" "Coach" "Club Member" "Matthew Sie" first
+
+Scenario: Redirected to profile page if trying to access change log not as administrator
+  Given "Joe Chen" logs in with correct password "88888888" and goes to profile page
+  Then I should not see "User Membership Change Log"
+  Then my path should be "/user/profile"
+  When I go to User Membership Change Log page
+  Then my path should be "/user/profile"

--- a/features/step_definitions/admin_elevate_steps.rb
+++ b/features/step_definitions/admin_elevate_steps.rb
@@ -7,8 +7,8 @@ And /selects status "(.*)" for "(.*)"/ do |status, name|
     select status, :from => "#{name}_user_membership"
 end
 
-Then /he should see membership status "(.*)" for "(.*)"/ do |status, name|
+Then /he should see attribute "(.*)" value "(.*)" for "(.*)"/ do |attribute, status, name|
     td = page.find(:css, 'td.name', text: name)
     tr = td.find(:xpath, './parent::tr')
-    expect(tr).to have_css('td.membership', text: status)
+    expect(tr).to have_css('td.' + attribute, text: status)
 end

--- a/features/step_definitions/membership_history_steps.rb
+++ b/features/step_definitions/membership_history_steps.rb
@@ -1,0 +1,24 @@
+Then /I should see the change of "(.*)" membership from "(.*)" to "(.*)" by "(.*)"/ do |changed, old, new_m, by|
+    td = page.find(:css, 'td.changed_name', text: changed)
+    tr = td.find(:xpath, './parent::tr')
+    expect(tr).to have_css('td.old', text: old)
+    expect(tr).to have_css('td.new', text: new_m)
+    expect(tr).to have_css('td.changed_by_name', text: by)
+end
+
+And /I should see these "(.*)" "(.*)" "(.*)" "(.*)" first/ do |changed, old, new_m, by|
+    tr = page.find(:xpath, ".//tbody//tr[1]")
+    expect(tr).to have_css('td.changed_name', text: changed)
+    expect(tr).to have_css('td.old', text: old)
+    expect(tr).to have_css('td.new', text: new_m)
+    expect(tr).to have_css('td.changed_by_name', text: by)
+end
+
+Then /my path should be "(.*)"/ do |pathasdf|
+    current_path = URI.parse(current_url).path
+    current_path.equal?(pathasdf)
+end
+
+When /I try to go to path "(.*)"/ do |path|
+    session.visit(path)
+end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -24,6 +24,9 @@ module NavigationHelpers
     when /^Login page$/i
       new_user_session_path
     
+    when /^User Membership Change Log page$/i
+      membership_history_path
+    
     when /^(.*)'s My Profile Page$/i
       user = User.find_by_name($1)
       member_profile_path :current_user => user 

--- a/test/controllers/membership_history_controller_test.rb
+++ b/test/controllers/membership_history_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MembershipHistoryControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/membership_histories.yml
+++ b/test/fixtures/membership_histories.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/membership_history_test.rb
+++ b/test/models/membership_history_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MembershipHistoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Admin users can navigate to a link that displays a table of all the changes to users membership statuses made by themselves, other admins, or managers. It displays the user whose membership was changed, the old membership status, the new membership status, the user who changed it, and the date and time it was changed.