### PR TITLE
Payment packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ script:
   # insert here any other steps needed (load other sample data, etc) before starting tests 
   # run RSpec tests, and capture coverage
   - bundle exec rspec
-  # - $CCTR format-coverage --output coverage/codeclimate.$SUITE.json
+  - $CCTR format-coverage --output coverage/codeclimate.$SUITE.json
   # - $CCTR format-coverage -d -t simplecov --output coverage/codeclimate.rspec.json --prefix /home/travis/build/zdehkordi/Project-Elevate
   # run Cucumber scenarios, and capture coverage. --strict means undefined steps result in a failure.
   - bundle exec cucumber --strict
-  - $CCTR format-coverage --output coverage/codeclimate.$SUITE.json
+  # - $CCTR format-coverage --output coverage/codeclimate.$SUITE.json
 
 after_script:
   # combine coverage from all suites, and upload to CodeClimate

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'activerecord-session_store', '~> 1.0'
 gem 'dotenv', '~> 2.2.1'
 # figaro
 gem 'figaro'
+gem 'font-awesome-sass', '~> 5.8.1'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,8 @@ GEM
       path_expander (~> 1.0)
       ruby_parser (~> 3.1, > 3.1.0)
       sexp_processor (~> 4.8)
+    font-awesome-sass (5.8.1)
+      sassc (>= 1.11)
     formatador (0.2.5)
     gherkin (5.1.0)
     globalid (0.4.2)
@@ -389,6 +391,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -469,6 +474,7 @@ DEPENDENCIES
   factory_bot_rails
   factory_girl_rails
   figaro
+  font-awesome-sass (~> 5.8.1)
   guard-rspec
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/app/assets/javascripts/payment_packages.coffee
+++ b/app/assets/javascripts/payment_packages.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/applications.css.scss
+++ b/app/assets/stylesheets/applications.css.scss
@@ -1,3 +1,6 @@
+@import "font-awesome-sprockets";
+@import "font-awesome";
+
 .flash-message {
   &.error {
     border: solid 4px #900;

--- a/app/assets/stylesheets/payment_packages.scss
+++ b/app/assets/stylesheets/payment_packages.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the payment_packages controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/payment_package_controller.rb
+++ b/app/controllers/payment_package_controller.rb
@@ -30,7 +30,8 @@ class PaymentPackageController < ApplicationController
     end
 
     def update
-        PaymentPackage.find(params[:id]).update_attributes!(params[:payment_package].permit(:name, :num_classes, :price))
+        par = params[:payment_package].reject{|_, v| v.blank?}
+        PaymentPackage.find(params[:id]).update_attributes!(par.permit(:name, :num_classes, :price))
         redirect_to payment_package_path
     end
 end

--- a/app/controllers/payment_package_controller.rb
+++ b/app/controllers/payment_package_controller.rb
@@ -1,5 +1,15 @@
 class PaymentPackageController < ApplicationController
+    before_action :require_admin_priv
+    before_action :authenticate_user!
+
+    def require_admin_priv
+        if current_user.membership != 'Administrator'
+            redirect_to root_path
+        end
+    end
+
     def index
-        
+        @packages = PaymentPackage.all
+        # render 'index'
     end
 end

--- a/app/controllers/payment_package_controller.rb
+++ b/app/controllers/payment_package_controller.rb
@@ -25,6 +25,12 @@ class PaymentPackageController < ApplicationController
     end
 
     def edit
-        
+        @package = PaymentPackage.find(params[:id])
+        @name = @package.name
+    end
+
+    def update
+        PaymentPackage.find(params[:id]).update_attributes!(params[:payment_package].permit(:name, :num_classes, :price))
+        redirect_to payment_package_path
     end
 end

--- a/app/controllers/payment_package_controller.rb
+++ b/app/controllers/payment_package_controller.rb
@@ -14,13 +14,13 @@ class PaymentPackageController < ApplicationController
     end
 
     def create
-        params[:payment_package].each do |k, v|
-            if v.empty?
-                flash[:alert] = 'Missing fields or non-unqiue name'
-                redirect_to payment_package_path && return
-            end
+        begin
+            params[:payment_package].require([:name, :num_classes, :price])
+            PaymentPackage.create!(params[:payment_package].permit(:name, :num_classes, :price))
+        rescue => ex
+            flash[:alert] = 'Missing fields or non-unqiue name'
         end
-        PaymentPackage.create!(params[:payment_package].permit(:name, :num_classes, :price))
+        
         redirect_to payment_package_path
     end
 end

--- a/app/controllers/payment_package_controller.rb
+++ b/app/controllers/payment_package_controller.rb
@@ -23,4 +23,8 @@ class PaymentPackageController < ApplicationController
         
         redirect_to payment_package_path
     end
+
+    def edit
+        
+    end
 end

--- a/app/controllers/payment_package_controller.rb
+++ b/app/controllers/payment_package_controller.rb
@@ -12,4 +12,7 @@ class PaymentPackageController < ApplicationController
         @packages = PaymentPackage.all
         # render 'index'
     end
+
+    def create
+    end
 end

--- a/app/controllers/payment_package_controller.rb
+++ b/app/controllers/payment_package_controller.rb
@@ -14,5 +14,13 @@ class PaymentPackageController < ApplicationController
     end
 
     def create
+        params[:payment_package].each do |k, v|
+            if v.empty?
+                flash[:alert] = 'Missing fields or non-unqiue name'
+                redirect_to payment_package_path && return
+            end
+        end
+        PaymentPackage.create!(params[:payment_package].permit(:name, :num_classes, :price))
+        redirect_to payment_package_path
     end
 end

--- a/app/controllers/payment_package_controller.rb
+++ b/app/controllers/payment_package_controller.rb
@@ -10,7 +10,6 @@ class PaymentPackageController < ApplicationController
 
     def index
         @packages = PaymentPackage.all
-        # render 'index'
     end
 
     def create
@@ -32,6 +31,11 @@ class PaymentPackageController < ApplicationController
     def update
         par = params[:payment_package].reject{|_, v| v.blank?}
         PaymentPackage.find(params[:id]).update_attributes!(par.permit(:name, :num_classes, :price))
+        redirect_to payment_package_path
+    end
+
+    def delete
+        PaymentPackage.destroy(params[:id])
         redirect_to payment_package_path
     end
 end

--- a/app/controllers/payment_package_controller.rb
+++ b/app/controllers/payment_package_controller.rb
@@ -1,0 +1,5 @@
+class PaymentPackageController < ApplicationController
+    def index
+        
+    end
+end

--- a/app/helpers/payment_packages_helper.rb
+++ b/app/helpers/payment_packages_helper.rb
@@ -1,0 +1,2 @@
+module PaymentPackagesHelper
+end

--- a/app/models/payment_package.rb
+++ b/app/models/payment_package.rb
@@ -1,0 +1,2 @@
+class PaymentPackage < ApplicationRecord
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,7 +13,9 @@
     <%= link_to "Logout", destroy_user_session_path, method: :delete, :class => 'navbar-link'  %> |
     <%= link_to "Book Lesson", booking_path, :class => 'navbar-link'  %>
     <br> <%= link_to "My Profile Page", member_profile_path %>
-    <br> <%= link_to "View Payment Packages", payment_package_path %>
+    <% if current_user.membership == 'Administrator '%>
+        <br> <%= link_to "View Payment Packages", payment_package_path %>
+    <% end %>
      <table class="table table-hover">
     <% @calendarsShow.each do |calendar| %>                    
         <tr>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,6 +13,7 @@
     <%= link_to "Logout", destroy_user_session_path, method: :delete, :class => 'navbar-link'  %> |
     <%= link_to "Book Lesson", booking_path, :class => 'navbar-link'  %>
     <br> <%= link_to "My Profile Page", member_profile_path %>
+    <br> <%= link_to "View Payment Packages", payment_package_path %>
      <table class="table table-hover">
     <% @calendarsShow.each do |calendar| %>                    
         <tr>

--- a/app/views/payment_package/edit.html.erb
+++ b/app/views/payment_package/edit.html.erb
@@ -1,0 +1,9 @@
+<h3>Edit <%= @name %> Package</h3> <br>
+<%= form_for :payment_package, url: update_payment_package_path do |f| %>
+  Name: <%= f.text_field :name, :value => @name %> <br>
+  Number of Classes: <%= f.number_field :num_classes, :value => @package.num_classes  %> <br>
+  Price: <%= f.number_field :price, :value => @package.price %> <br>
+  <%= f.submit value: 'Update package' %>
+<% end %>
+
+<%= link_to "Back", :back %>

--- a/app/views/payment_package/edit.html.erb
+++ b/app/views/payment_package/edit.html.erb
@@ -1,3 +1,7 @@
+<% if alert %>
+    <p class="alert alert-danger"><%= alert %></p>
+<% end %>
+
 <h3>Edit <%= @name %> Package</h3> <br>
 <%= form_for :payment_package, url: update_payment_package_path do |f| %>
   Name: <%= f.text_field :name, :value => @name %> <br>

--- a/app/views/payment_package/index.html.erb
+++ b/app/views/payment_package/index.html.erb
@@ -1,0 +1,24 @@
+<h3 style="text-align:center;"> Payment Package Portal </h3>
+
+<table class="table table-hover">
+<thead>
+    <tr>
+      <th>Package Name</th>
+      <th>Number of Classes</th>
+      <th>Price</th>
+      <th>Updated At</th>
+    </tr>
+</thead>
+  <tbody >
+    <% @packages.each do |record| %>
+      <tr>
+        <td class="package_name"><%= record.name%></td>
+        <td class="num_classes"><%= record.num_classes%></td>
+        <td class="price"><%= '$' + record.price.to_s%></td>
+        <td><%= record.updated_at.in_time_zone("Pacific Time (US & Canada)").strftime("%B %d, %Y %I:%M:%S %p %Z")%></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= link_to "Back", :back %>

--- a/app/views/payment_package/index.html.erb
+++ b/app/views/payment_package/index.html.erb
@@ -22,7 +22,7 @@
         <td class="num_classes"><%= record.num_classes%></td>
         <td class="price"><%= '$' + record.price.to_s%></td>
         <td><%= record.updated_at.in_time_zone("Pacific Time (US & Canada)").strftime("%B %d, %Y %I:%M:%S %p %Z")%></td>
-        <td><%= link_to icon('far', 'edit'), edit_payment_package %>
+        <td><%= link_to icon('far', 'edit'), edit_payment_package_path(record.id) %>
         </div>
       </tr>
     </div>

--- a/app/views/payment_package/index.html.erb
+++ b/app/views/payment_package/index.html.erb
@@ -1,5 +1,9 @@
 <h3 style="text-align:center;"> Payment Package Portal </h3>
 
+<% if alert %>
+    <p class="alert alert-danger"><%= alert %></p>
+<% end %>
+
 <table class="table table-hover">
 <thead>
     <tr>
@@ -11,30 +15,25 @@
 </thead>
   <tbody >
     <% @packages.each do |record| %>
+    <div id=<%= 'package_' + record.id.to_s %>>
       <tr>
         <td class="package_name"><%= record.name%></td>
         <td class="num_classes"><%= record.num_classes%></td>
         <td class="price"><%= '$' + record.price.to_s%></td>
         <td><%= record.updated_at.in_time_zone("Pacific Time (US & Canada)").strftime("%B %d, %Y %I:%M:%S %p %Z")%></td>
+        </div>
       </tr>
+    </div>
     <% end %>
   </tbody>
 </table>
 
-<%= form_for :user, url: add_availabilities_path do |f| %>
-  <div class="date">
-    Choose Date: <br />
-    <%= f.select :day, Date::DAYNAMES %> <br />
-    Start Time: <br />
-    <%= f.select :start_time, CoachAvailability.availibility %> :
-    <%= f.select :start_time_s, ['00', '30'] %> 
-    <%= f.select :start_time_ampm, ['AM', 'PM'] %> <br /> 
-    End Time: <br />
-    <%= f.select :end_time, CoachAvailability.availibility %> :
-    <%= f.select :end_time_s, ['00', '30'] %>
-    <%= f.select :end_time_ampm, ['AM', 'PM'] %><br />
-    <%= f.submit value: 'Add availibility' %>
-  </div>
+<h3>Add Payment Package</h3> <br>
+<%= form_for :payment_package, url: add_payment_package_path do |f| %>
+  Name: <%= f.text_field :name %> <br>
+  Number of Classes: <%= f.number_field :num_classes %> <br>
+  Price: <%= f.number_field :price %> <br>
+  <%= f.submit value: 'Add package' %>
 <% end %>
 
 <%= link_to "Back", :back %>

--- a/app/views/payment_package/index.html.erb
+++ b/app/views/payment_package/index.html.erb
@@ -11,6 +11,7 @@
       <th>Number of Classes</th>
       <th>Price</th>
       <th>Updated At</th>
+      <th>Edit</th>
     </tr>
 </thead>
   <tbody >
@@ -21,6 +22,7 @@
         <td class="num_classes"><%= record.num_classes%></td>
         <td class="price"><%= '$' + record.price.to_s%></td>
         <td><%= record.updated_at.in_time_zone("Pacific Time (US & Canada)").strftime("%B %d, %Y %I:%M:%S %p %Z")%></td>
+        <td><%= link_to icon('far', 'edit'), edit_payment_package %>
         </div>
       </tr>
     </div>

--- a/app/views/payment_package/index.html.erb
+++ b/app/views/payment_package/index.html.erb
@@ -21,4 +21,20 @@
   </tbody>
 </table>
 
+<%= form_for :user, url: add_availabilities_path do |f| %>
+  <div class="date">
+    Choose Date: <br />
+    <%= f.select :day, Date::DAYNAMES %> <br />
+    Start Time: <br />
+    <%= f.select :start_time, CoachAvailability.availibility %> :
+    <%= f.select :start_time_s, ['00', '30'] %> 
+    <%= f.select :start_time_ampm, ['AM', 'PM'] %> <br /> 
+    End Time: <br />
+    <%= f.select :end_time, CoachAvailability.availibility %> :
+    <%= f.select :end_time_s, ['00', '30'] %>
+    <%= f.select :end_time_ampm, ['AM', 'PM'] %><br />
+    <%= f.submit value: 'Add availibility' %>
+  </div>
+<% end %>
+
 <%= link_to "Back", :back %>

--- a/app/views/payment_package/index.html.erb
+++ b/app/views/payment_package/index.html.erb
@@ -12,6 +12,7 @@
       <th>Price</th>
       <th>Updated At</th>
       <th>Edit</th>
+      <th>Delete</th>
     </tr>
 </thead>
   <tbody >
@@ -23,6 +24,7 @@
         <td class="price"><%= '$' + record.price.to_s%></td>
         <td><%= record.updated_at.in_time_zone("Pacific Time (US & Canada)").strftime("%B %d, %Y %I:%M:%S %p %Z")%></td>
         <td><%= link_to icon('far', 'edit'), edit_payment_package_path(record.id), :id => 'edit_' + record.id.to_s %>
+        <td><%= link_to icon('far', 'trash-alt'), delete_payment_package_path(record.id), :id => 'delete_' + record.id.to_s, :method => :delete %>
         </div>
       </tr>
     </div>

--- a/app/views/payment_package/index.html.erb
+++ b/app/views/payment_package/index.html.erb
@@ -22,7 +22,7 @@
         <td class="num_classes"><%= record.num_classes%></td>
         <td class="price"><%= '$' + record.price.to_s%></td>
         <td><%= record.updated_at.in_time_zone("Pacific Time (US & Canada)").strftime("%B %d, %Y %I:%M:%S %p %Z")%></td>
-        <td><%= link_to icon('far', 'edit'), edit_payment_package_path(record.id) %>
+        <td><%= link_to icon('far', 'edit'), edit_payment_package_path(record.id), :id => 'edit_' + record.id.to_s %>
         </div>
       </tr>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
   
   get 'user/booking' => 'user#booking', :as => 'booking'
   post 'charges/checkout' => 'charges#checkout', :as => 'checkout'
+
+  get 'user/payments' => 'payment_package#index', :as => 'payment_package'
   
   get 'user/calendar' => 'user#calendar', :as => 'user_calendar'
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
 
   get 'user/payments' => 'payment_package#index', :as => 'payment_package'
   post 'user/payments/add' => 'payment_package#create', :as => 'add_payment_package'
+  get 'user/payments/:id/edit' => 'payment_package#edit', :as => 'edit_payment_package'
+  post 'user/payments/:id/edit' => 'payment_package#update', :as => 'update_payment_package'
   
   get 'user/calendar' => 'user#calendar', :as => 'user_calendar'
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   post 'user/payments/add' => 'payment_package#create', :as => 'add_payment_package'
   get 'user/payments/:id/edit' => 'payment_package#edit', :as => 'edit_payment_package'
   post 'user/payments/:id/edit' => 'payment_package#update', :as => 'update_payment_package'
+  delete 'user/payments/:id' => 'payment_package#delete', :as => 'delete_payment_package'
   
   get 'user/calendar' => 'user#calendar', :as => 'user_calendar'
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   post 'charges/checkout' => 'charges#checkout', :as => 'checkout'
 
   get 'user/payments' => 'payment_package#index', :as => 'payment_package'
+  post 'user/payments/add' => 'payment_package#create', :as => 'add_payment_package'
   
   get 'user/calendar' => 'user#calendar', :as => 'user_calendar'
   

--- a/db/migrate/20190423174402_create_payment_packages.rb
+++ b/db/migrate/20190423174402_create_payment_packages.rb
@@ -1,7 +1,7 @@
 class CreatePaymentPackages < ActiveRecord::Migration[5.2]
   def change
     create_table :payment_packages do |t|
-      t.string :name, null: false
+      t.string :name, null: false, :unique => true
       t.integer :num_classes, null: false
       t.integer :price, null: false
       t.timestamps

--- a/db/migrate/20190423174402_create_payment_packages.rb
+++ b/db/migrate/20190423174402_create_payment_packages.rb
@@ -1,0 +1,10 @@
+class CreatePaymentPackages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :payment_packages do |t|
+      t.string :name, null: false
+      t.integer :num_classes, null: false
+      t.integer :price, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_15_204348) do
+ActiveRecord::Schema.define(version: 2019_04_23_174402) do
 
   create_table "calendars", force: :cascade do |t|
     t.string "name"
@@ -38,6 +38,14 @@ ActiveRecord::Schema.define(version: 2019_04_15_204348) do
     t.integer "changed_by_id", null: false
     t.string "old_membership", null: false
     t.string "new_membership", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "payment_packages", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "num_classes", null: false
+    t.integer "price", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2019_04_15_204348) do
     t.integer "OtherId"
     t.datetime "start_time"
     t.datetime "end_time"
-    t.string "typeEvent"
+    t.boolean "typeEvent"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,8 +35,10 @@ calendars.each do |calendar|
   Calendar.create!(calendar)
 end
 
-# <% if (user.my_admin.eql?(current_user.full_name)) %>
-  # <%= user.full_name %><br />
-  # <%= f.label "User membership" %><br />
-  # <%= f.text_field :membership, autofocus: true, autocomplete: "user_membership" %><br />
-# <% end %>
+payment_packages = [{:name => "Bronze", :num_classes => 5, :price => 100}, 
+                    {:name => "Silver", :num_classes => 10, :price => 175}, 
+                    {:name => "Gold", :num_classes => 20, :price => 300}]
+
+payment_packages.each do |pp|
+  PaymentPackage.create!(pp)
+end

--- a/features/admin_create_payment_package.feature
+++ b/features/admin_create_payment_package.feature
@@ -7,23 +7,23 @@ Feature: Add payment pacakge as a admin
 Background: Users in the Database
  Given the following users exist:
   | id | name            | email                    | password | membership    |
-  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Admin         |
+  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Administrator         |
 And "Pizza" logs in with correct credentials with password "12345678"
 And I go to Payment Packages Page
-When I fill in "new_package_name" with "Platinum"
-And I fill in "new_package_num_classes" with "10"
-
 
 Scenario: Add package successfully
-  And I fill in "new_package_price" with "200"
+  When I fill in "payment_package_name" with "Platinum"
+  And I fill in "payment_package_num_classes" with "10"
+  And I fill in "payment_package_price" with "200"
   And I press "Add package"
-  Then I should see "Platinum" within "package_1"
-  Then I should see "10" within "package_1"
-  Then I should see "200" within "package_1"
+  Then I should be on Payment Packages Page
+  Then I should see "Platinum"
+  Then I should see "10"
+  Then I should see "200"
 
 Scenario: Add package but fill in form incorrectly
-  And I fill in "new_package_price" with "blahbashdfldsadf"
+  When I fill in "payment_package_name" with "Gold"
   And I press "Add package"
-  Then I should not see "Platinum" within "package_1"
-  Then I should not see "10" within "package_1"
-  Then I should not see "200" within "package_1"
+  Then I should be on Payment Packages Page
+  Then I should not see "Gold"
+  And I should see "Missing fields"

--- a/features/admin_create_payment_package.feature
+++ b/features/admin_create_payment_package.feature
@@ -1,0 +1,29 @@
+Feature: Add payment pacakge as a admin
+ 
+    As a Admin
+    I want create package credits
+    So that I can offer discounts for buying credits in bulk
+
+Background: Users in the Database
+ Given the following users exist:
+  | id | name            | email                    | password | membership    |
+  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Admin         |
+And "Pizza" logs in with correct credentials with password "12345678"
+And I go to Payment Packages Page
+When I fill in "new_package_name" with "Platinum"
+And I fill in "new_package_num_classes" with "10"
+
+
+Scenario: Add package successfully
+  And I fill in "new_package_price" with "200"
+  And I press "Add package"
+  Then I should see "Platinum" within "package_1"
+  Then I should see "10" within "package_1"
+  Then I should see "200" within "package_1"
+
+Scenario: Add package but fill in form incorrectly
+  And I fill in "new_package_price" with "blahbashdfldsadf"
+  And I press "Add package"
+  Then I should not see "Platinum" within "package_1"
+  Then I should not see "10" within "package_1"
+  Then I should not see "200" within "package_1"

--- a/features/admin_create_payment_package.feature
+++ b/features/admin_create_payment_package.feature
@@ -22,8 +22,8 @@ Scenario: Add package successfully
   Then I should see "200"
 
 Scenario: Add package but fill in form incorrectly
-  When I fill in "payment_package_name" with "Gold"
+  When I fill in "payment_package_name" with "Red"
   And I press "Add package"
   Then I should be on Payment Packages Page
-  Then I should not see "Gold"
+  Then I should not see "Red"
   And I should see "Missing fields"

--- a/features/admin_delete_payment_package.feature
+++ b/features/admin_delete_payment_package.feature
@@ -1,0 +1,24 @@
+Feature: Delete payment pacakge as a admin
+ 
+    As a Admin
+    I want delete package credits
+    So that I can stop offering discounts for buying credits in bulk
+
+Background: Users in the Database
+ Given the following users exist:
+  | id | name            | email                    | password | membership    |
+  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Administrator         |
+Given the following payment_packages exist:
+    |id  | name  |   num_classes |   price   |
+    | 1  | Gold  |   10          |   10      |
+    | 2  | Red   |   200         |   2000    |
+And "Pizza" logs in with correct credentials with password "12345678"
+And I go to Payment Packages Page
+
+Scenario: Delete package successfully
+  And I follow "delete_1"
+  Then I should be on Payment Packages Page
+  Then I should see "Red"
+  And I should not see "Gold"
+  Then I follow "delete_2"
+  Then I should not see "Red"

--- a/features/admin_delete_payment_package.feature
+++ b/features/admin_delete_payment_package.feature
@@ -11,19 +11,19 @@ Background: Users in the Database
   | 7  | Zac             | zac@gmail.com        | asdfjkl; | Club Member         |
 Given the following payment_packages exist:
     |id  | name  |   num_classes |   price   |
-    | 1  | Green  |   10          |   10      |
-    | 2  | Red   |   200         |   2000    |
-    | 3  | Blue  |   200         |   2000    |
+    | 4  | Green  |   10          |   10      |
+    | 5  | Red   |   200         |   2000    |
+    | 6  | Blue  |   200         |   2000    |
 
 
 Scenario: Delete package successfully
   And "Pizza" logs in with correct credentials with password "12345678"
   And I go to Payment Packages Page
-  And I follow "delete_1"
+  And I follow "delete_4"
   Then I should be on Payment Packages Page
   Then I should see "Red"
   And I should not see "Green"
-  Then I follow "delete_2"
+  Then I follow "delete_5"
   Then I should not see "Red"
 
 Scenario: Try to go to package page not as an admin

--- a/features/admin_delete_payment_package.feature
+++ b/features/admin_delete_payment_package.feature
@@ -8,17 +8,25 @@ Background: Users in the Database
  Given the following users exist:
   | id | name            | email                    | password | membership    |
   | 6  | Pizza           | pizza@gmail.com       | 12345678 | Administrator         |
+  | 7  | Zac             | zac@gmail.com        | asdfjkl; | Club Member         |
 Given the following payment_packages exist:
     |id  | name  |   num_classes |   price   |
     | 1  | Gold  |   10          |   10      |
     | 2  | Red   |   200         |   2000    |
-And "Pizza" logs in with correct credentials with password "12345678"
-And I go to Payment Packages Page
+    | 3  | Blue  |   200         |   2000    |
+
 
 Scenario: Delete package successfully
+  And "Pizza" logs in with correct credentials with password "12345678"
+  And I go to Payment Packages Page
   And I follow "delete_1"
   Then I should be on Payment Packages Page
   Then I should see "Red"
   And I should not see "Gold"
   Then I follow "delete_2"
   Then I should not see "Red"
+
+Scenario: Try to go to package page not as an admin
+  And "Zac" logs in with correct credentials with password "asdfjkl;"
+  And I go to Payment Packages Page
+  Then I should be on the home page

--- a/features/admin_delete_payment_package.feature
+++ b/features/admin_delete_payment_package.feature
@@ -11,7 +11,7 @@ Background: Users in the Database
   | 7  | Zac             | zac@gmail.com        | asdfjkl; | Club Member         |
 Given the following payment_packages exist:
     |id  | name  |   num_classes |   price   |
-    | 1  | Gold  |   10          |   10      |
+    | 1  | Green  |   10          |   10      |
     | 2  | Red   |   200         |   2000    |
     | 3  | Blue  |   200         |   2000    |
 
@@ -22,7 +22,7 @@ Scenario: Delete package successfully
   And I follow "delete_1"
   Then I should be on Payment Packages Page
   Then I should see "Red"
-  And I should not see "Gold"
+  And I should not see "Green"
   Then I follow "delete_2"
   Then I should not see "Red"
 

--- a/features/admin_update_payment_package.feature
+++ b/features/admin_update_payment_package.feature
@@ -8,13 +8,14 @@ Background: Users in the Database
  Given the following users exist:
   | id | name            | email                    | password | membership    |
   | 6  | Pizza           | pizza@gmail.com       | 12345678 | Administrator         |
+Given the following payment_packages exist:
+    |id  | name  |   num_classes |   price   |
+    | 4  | Green  |   10          |   10      |
+    | 5  | Red   |   200         |   2000    |
+    | 6  | Blue  |   200         |   2000    |
 And "Pizza" logs in with correct credentials with password "12345678"
 And I go to Payment Packages Page
-And I fill in "payment_package_name" with "Red"
-And I fill in "payment_package_num_classes" with "10"
-And I fill in "payment_package_price" with "200"
-And I press "Add package"
-Then I follow "edit_1"
+Then I follow "edit_5"
 
 Scenario: Edit package successfully
   When I fill in "payment_package_name" with "AMAZING DEAL"
@@ -23,11 +24,7 @@ Scenario: Edit package successfully
   And I press "Update package"
   Then I should be on Payment Packages Page
   Then I should see "AMAZING DEAL"
-  Then I should see "15"
-  Then I should see "250"
   And I should not see "Red"
-  And I should not see "10"
-  And I should not see "200"
 
 Scenario: Add package but fill only change one form
   When I fill in "payment_package_name" with "Blue"

--- a/features/admin_update_payment_package.feature
+++ b/features/admin_update_payment_package.feature
@@ -10,7 +10,7 @@ Background: Users in the Database
   | 6  | Pizza           | pizza@gmail.com       | 12345678 | Administrator         |
 And "Pizza" logs in with correct credentials with password "12345678"
 And I go to Payment Packages Page
-And I fill in "payment_package_name" with "Platinum"
+And I fill in "payment_package_name" with "Red"
 And I fill in "payment_package_num_classes" with "10"
 And I fill in "payment_package_price" with "200"
 And I press "Add package"
@@ -25,14 +25,14 @@ Scenario: Edit package successfully
   Then I should see "AMAZING DEAL"
   Then I should see "15"
   Then I should see "250"
-  And I should not see "Platinum"
+  And I should not see "Red"
   And I should not see "10"
   And I should not see "200"
 
 Scenario: Add package but fill only change one form
-  When I fill in "payment_package_name" with "Gold"
+  When I fill in "payment_package_name" with "Blue"
   And I press "Update package"
   Then I should be on Payment Packages Page
-  Then I should see "Gold"
+  Then I should see "Blue"
   Then I should see "10"
   Then I should see "200"

--- a/features/admin_update_payment_package.feature
+++ b/features/admin_update_payment_package.feature
@@ -1,0 +1,44 @@
+Feature: Update payment pacakge as a admin
+ 
+    As a Admin
+    I want update package credits
+    So that I can offer discounts for buying credits in bulk
+
+Background: Users in the Database
+ Given the following users exist:
+  | id | name            | email                    | password | membership    |
+  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Administrator         |
+And "Pizza" logs in with correct credentials with password "12345678"
+And I go to Payment Packages Page
+And I fill in "payment_package_name" with "Platinum"
+And I fill in "payment_package_num_classes" with "10"
+And I fill in "payment_package_price" with "200"
+And I press "Add package"
+Then I press "edit_1"
+
+Scenario: Edit package successfully
+  When I fill in "payment_package_name" with "AMAZING DEAL"
+  And I fill in "payment_package_num_classes" with "15"
+  And I fill in "payment_package_price" with "250"
+  And I press "Update package"
+  Then I should be on Payment Packages Page
+  Then I should see "AMAZING DEAL"
+  Then I should see "15"
+  Then I should see "250"
+  And I should not see "Platinum", "10", "200"
+
+Scenario: Add package but fill in form incorrectly
+  When I fill in "payment_package_name" with "Gold"
+  And I fill in "payment_package_num_classes" with ""
+  And I fill in "payment_package_price" with ""
+  And I press "Update package"
+  Then I should be on Payment Packages Page
+  And I should see "Missing fields"
+
+Scenario: Add package but fill only change one form
+  When I fill in "payment_package_name" with "Gold"
+  And I press "Update package"
+  Then I should be on Payment Packages Page
+  Then I should see "Gold"
+  Then I should see "10"
+  Then I should see "200"

--- a/features/admin_update_payment_package.feature
+++ b/features/admin_update_payment_package.feature
@@ -14,7 +14,7 @@ And I fill in "payment_package_name" with "Platinum"
 And I fill in "payment_package_num_classes" with "10"
 And I fill in "payment_package_price" with "200"
 And I press "Add package"
-Then I press "edit_1"
+Then I follow "edit_1"
 
 Scenario: Edit package successfully
   When I fill in "payment_package_name" with "AMAZING DEAL"
@@ -25,15 +25,9 @@ Scenario: Edit package successfully
   Then I should see "AMAZING DEAL"
   Then I should see "15"
   Then I should see "250"
-  And I should not see "Platinum", "10", "200"
-
-Scenario: Add package but fill in form incorrectly
-  When I fill in "payment_package_name" with "Gold"
-  And I fill in "payment_package_num_classes" with ""
-  And I fill in "payment_package_price" with ""
-  And I press "Update package"
-  Then I should be on Payment Packages Page
-  And I should see "Missing fields"
+  And I should not see "Platinum"
+  And I should not see "10"
+  And I should not see "200"
 
 Scenario: Add package but fill only change one form
   When I fill in "payment_package_name" with "Gold"

--- a/features/step_definitions/admin_payment_package_steps.rb
+++ b/features/step_definitions/admin_payment_package_steps.rb
@@ -1,0 +1,5 @@
+Given /the following payment_packages exist/ do |pp_table|
+    pp_table.hashes.each do |pp|
+      PaymentPackage.create pp
+    end
+  end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -34,11 +34,12 @@ module NavigationHelpers
     when /^(.*)'s Availabilities Page$/i
       user = User.find_by_name($1)
       availabilities_path :current_user => user 
+
     when /^Buy Credits page$/i
       new_charge_path
 
-
-
+    when /^Payment Packages Page$/i
+      payment_package_path
 
     else
       begin

--- a/test/controllers/payment_packages_controller_test.rb
+++ b/test/controllers/payment_packages_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PaymentPackagesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/payment_packages.yml
+++ b/test/fixtures/payment_packages.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/payment_package_test.rb
+++ b/test/models/payment_package_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PaymentPackageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Feature: Admin can create payment custom packages with customization number of classes and prices
- CRUD operations for the new PaymentPackage resource
- Accessible via /user/payments (thoughts on this URI?)

To access the view you must be logged in as an admin and click the View Payment Packages link on the home page (this link will not appear if you are not an admin)

Note: This is not yet integrated with the actual payment processing/booking workflow