### PR TITLE
Email verif

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,0 @@
-class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
-end

--- a/app/mailers/auth_mailer.rb
+++ b/app/mailers/auth_mailer.rb
@@ -1,0 +1,17 @@
+class AuthMailer < Devise::Mailer
+  helper :application
+  include Devise::Controllers::UrlHelpers
+  default template_path: 'devise/mailer'
+  default from: 'projectElevateDev@gmail.com'
+  layout 'mailer'
+  
+  def confirmation_instructions(record, token, opts={})
+    # Use different e-mail templates for signup e-mail confirmation and for when a user changes e-mail address.
+    if record.pending_reconfirmation?
+      devise_mail(record, :email_changed, opts)
+    else
+      devise_mail(record, :confirmation_instructions, opts)
+    end
+  end
+  
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :confirmable
 
   def self.admin_update_membership_to(curr_user)
     statuses = ['Club Member', 'Coach', 'Manager']

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,9 @@
-<p>Welcome <%= @email %>!</p>
+<p>Welcome <%= @resource.name %>!</p>
 
 <p>You can confirm your account email through the link below:</p>
 
 <p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+
+<br> Welcome to the Team!
+<br> - The Project Elevate Team 
+</p>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,4 +1,4 @@
-<p>Welcome <%= @resource.name %>!</p>
+<p>Hello <%= @resource.name %>!</p>
 
 <p>You can confirm your account email through the link below:</p>
 

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
 <p>Hello <%= @resource.name %>!</p>
-
+<p> Welcome to the Club!</p>
 <p>You can confirm your account email through the link below:</p>
 
 <p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -2,7 +2,7 @@
 <p> Welcome to the Club!</p>
 <p>You can confirm your account email through the link below:</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @resource.confirmation_token) %></p>
 
 <br> Welcome to the Team!
 <br> - The Project Elevate Team 

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,7 +1,14 @@
-<p>Hello <%= @email %>!</p>
+<p>Hello <%= @resource.name %>!</p>
 
 <% if @resource.try(:unconfirmed_email?) %>
-  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+  <p>We're contacting you to notify you that your account email is being changed to <%= @resource.unconfirmed_email %>.</p>
 <% else %>
-  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+  <p>We're contacting you to notify you that your account email has been changed to <%= @resource.email %>.</p>
 <% end %>
+<p>You can confirm your new account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @resource.confirmation_token) %></p>
+
+<p>In the future, please use <%= @resource.unconfirmed_email %> to login. </p>
+<br> - The Project Elevate Team 
+</p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -9,6 +9,6 @@
 
 <p><%= link_to 'Confirm my account', confirmation_url(@resource, :confirmation_token => @resource.confirmation_token) %></p>
 
-<p>In the future, please use <%= @resource.unconfirmed_email %> to login. </p>
+<p>In the future, please use <%= @resource.unconfirmed_email %> to login to your account. </p>
 <br> - The Project Elevate Team 
 </p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,7 +4,6 @@ Rails.application.configure do
   # Confirm user account email
   config.action_mailer.default_url_options = { :host => 'localhost:3000' }
   config.action_mailer.delivery_method = :smtp
-  # config.action_mailer.smtp_settings = {:address => "localhost", :port => 1025}
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.smtp_settings = 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,8 +4,19 @@ Rails.application.configure do
   # Confirm user account email
   config.action_mailer.default_url_options = { :host => 'localhost:3000' }
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {:address => "localhost", :port => 1025}
+  # config.action_mailer.smtp_settings = {:address => "localhost", :port => 1025}
   config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.smtp_settings = 
+  {
+    :address              => 'smtp.gmail.com',
+    :port                 => 587,
+    :domain               => 'gmail.com', #you can also use google.com
+    :authentication       => :plain,
+    :user_name            => 'projectElevateDev@gmail.com',
+    :enable_starttls_auto => true,
+    :password             => 'LetsElevate!'
+  }
 
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
@@ -35,11 +46,6 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
   config.active_storage.service = :local
-
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-  
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,12 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Confirm user account email
+  config.action_mailer.default_url_options = { :host => 'localhost:3000' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {:address => "localhost", :port => 1025}
+  config.action_mailer.perform_deliveries = true
+
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
@@ -33,7 +39,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,23 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Confirm user account email
+  config.action_mailer.default_url_options = { :host => 'project-elevate.herokuapp.com' }
+  config.action_mailer.delivery_method = :smtp
+  # config.action_mailer.smtp_settings = {:address => "localhost", :port => 1025}
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.smtp_settings = 
+  {
+    :address              => 'smtp.gmail.com',
+    :port                 => 587,
+    :domain               => 'gmail.com', #you can also use google.com
+    :authentication       => :plain,
+    :user_name            => 'projectElevateDev@gmail.com',
+    :enable_starttls_auto => true,
+    :password             => 'LetsElevate!'
+  }
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,7 +4,6 @@ Rails.application.configure do
   # Confirm user account email
   config.action_mailer.default_url_options = { :host => 'project-elevate.herokuapp.com' }
   config.action_mailer.delivery_method = :smtp
-  # config.action_mailer.smtp_settings = {:address => "localhost", :port => 1025}
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.smtp_settings = 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,8 @@ Rails.application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
+  config.action_mailer.default_url_options = {:host => "localhost:3000"}
+
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'matthewsie@hotmail.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -21,7 +21,7 @@ Devise.setup do |config|
   config.mailer_sender = 'projectElevateDev@gmail.com'
 
   # Configure the class responsible to send e-mails.
-  config.mailer = 'MyMailer'
+  config.mailer = 'AuthMailer'
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'matthewsie@hotmail.com'
+  config.mailer_sender = 'projectElevateDev@gmail.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -21,7 +21,7 @@ Devise.setup do |config|
   config.mailer_sender = 'projectElevateDev@gmail.com'
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'MyMailer'
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -18,15 +18,15 @@ en:
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: "[Project Elevate] Confirm Your Email"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "[Project Elevate] Reset password instructions"
       unlock_instructions:
-        subject: "Unlock instructions"
+        subject: "[Project Elevate] Unlock instructions"
       email_changed:
-        subject: "Email Changed"
+        subject: "[Project Elevate] Email Changed"
       password_change:
-        subject: "Password Changed"
+        subject: "[Project Elevate] Password Changed"
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."

--- a/db/migrate/20190425213247_add_confirmable_to_devise.rb
+++ b/db/migrate/20190425213247_add_confirmable_to_devise.rb
@@ -1,0 +1,12 @@
+class AddConfirmableToDeviseV1 < ActiveRecord::Migration[4.2]
+  def change
+    change_table(:users) do |t|
+       # Confirmable
+       t.string   :confirmation_token
+       t.datetime :confirmed_at
+       t.datetime :confirmation_sent_at
+       t.string   :unconfirmed_email # Only if using reconfirmable
+     end
+     add_index  :users, :confirmation_token, :unique => true 
+   end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_15_204348) do
+ActiveRecord::Schema.define(version: 2019_04_25_213247) do
 
   create_table "calendars", force: :cascade do |t|
     t.string "name"
@@ -56,6 +56,11 @@ ActiveRecord::Schema.define(version: 2019_04_15_204348) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,11 +7,11 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 
-users = [{:name => 'Joe Chen', :email => 'chenjoe@gmail.com', :password => '88888888', :membership => 'Club Member'},
-    	  {:name => 'Roger Destroyer', :email => 'rogerahh@gmail.com', :password => '12345678', :membership => 'Coach'},
-				{:name => 'Matthew Sie', :email => 'matthew.sie@berkeley.edu', :password => 'dabaka22', :membership => 'Administrator'},
-				{:name => 'John Doe', :email => 'johndoe@gmail.com', :password => '12345678', :membership => 'Manager'},
-				{:name => 'Jason Yang', :email => 'jason@gmail.com', :password => '123456', :membership => 'Club Member'}
+users = [{:name => 'Joe Chen', :email => 'chenjoe@gmail.com', :password => '88888888', :membership => 'Club Member', :confirmed_at => Time.now.utc},
+    	  {:name => 'Roger Destroyer', :email => 'rogerahh@gmail.com', :password => '12345678', :membership => 'Coach', :confirmed_at => Time.now.utc},
+				{:name => 'Matthew Sie', :email => 'matthew.sie@berkeley.edu', :password => 'dabaka22', :membership => 'Administrator', :confirmed_at => Time.now.utc},
+				{:name => 'John Doe', :email => 'johndoe@gmail.com', :password => '12345678', :membership => 'Manager', :confirmed_at => Time.now.utc},
+				{:name => 'Jason Yang', :email => 'jason@gmail.com', :password => '123456', :membership => 'Club Member', :confirmed_at => Time.now.utc}
   	 ]
 
 users.each do |user|

--- a/features/add_availability.feature
+++ b/features/add_availability.feature
@@ -6,8 +6,8 @@ Feature: Add availability as a coach
 
 Background: Users in the Database
  Given the following users exist:
-  | id | name            | email                    | password | membership    |
-  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Coach         |
+  | id | name            | email                    | password | membership    | confirmed_at |
+  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Coach         | 2013-02-02 01:00:00 UTC |
 And the following availabilities exist:
   | coach_id     | day      | start_time    | end_time  |
   | 6            | Sunday   | 9am           | 12pm      |

--- a/features/admin_create_payment_package.feature
+++ b/features/admin_create_payment_package.feature
@@ -6,8 +6,8 @@ Feature: Add payment pacakge as a admin
 
 Background: Users in the Database
  Given the following users exist:
-  | id | name            | email                    | password | membership    |
-  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Administrator         |
+  | id | name            | email                    | password | membership    | confirmed_at |
+  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Administrator         | 2013-02-02 01:00:00 UTC |
 And "Pizza" logs in with correct credentials with password "12345678"
 And I go to Payment Packages Page
 

--- a/features/admin_delete_payment_package.feature
+++ b/features/admin_delete_payment_package.feature
@@ -6,9 +6,10 @@ Feature: Delete payment pacakge as a admin
 
 Background: Users in the Database
  Given the following users exist:
-  | id | name            | email                    | password | membership    |
-  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Administrator         |
-  | 7  | Zac             | zac@gmail.com        | asdfjkl; | Club Member         |
+  | id | name            | email                    | password | membership    | confirmed_at |
+  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Administrator         | 2013-02-02 01:00:00 UTC |
+  | 7  | Zac             | zac@gmail.com        | asdfjkl; | Club Member         | 2013-02-02 01:00:00 UTC |
+
 Given the following payment_packages exist:
     |id  | name  |   num_classes |   price   |
     | 4  | Green  |   10          |   10      |

--- a/features/admin_elevate.feature
+++ b/features/admin_elevate.feature
@@ -7,11 +7,11 @@ Feature: (D)elevate other users as Admin
 Background: Users in the Database
 
  Given the following users exist:
-  | name            | email                    | password | membership    |
-  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   |
-  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator |
-  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         |
-  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       |
+  | name            | email                    | password | membership    | confirmed_at             |
+  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   | 2013-02-02 01:00:00 UTC  |
+  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator | 2013-02-02 01:00:00 UTC  |
+  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         | 2013-02-02 01:00:00 UTC  |
+  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       | 2013-02-02 01:00:00 UTC  |
 
 And I go to Login page
 

--- a/features/admin_update_payment_package.feature
+++ b/features/admin_update_payment_package.feature
@@ -6,8 +6,8 @@ Feature: Update payment pacakge as a admin
 
 Background: Users in the Database
  Given the following users exist:
-  | id | name            | email                    | password | membership    |
-  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Administrator         |
+  | id | name            | email                    | password | membership    | confirmed_at |
+  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Administrator         | 2013-02-02 01:00:00 UTC |
 Given the following payment_packages exist:
     |id  | name  |   num_classes |   price   |
     | 4  | Green  |   10          |   10      |

--- a/features/calendar.feature
+++ b/features/calendar.feature
@@ -7,12 +7,12 @@ Feature: View Calendar list and buttons
 Background: Users in the Database
 
  Given the following users exist:
-  | name            | email                    | password | membership    |
-  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   |
-  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator |
-  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         |
-  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       |
-  | Jason Yang      | jason@gmail.com          | 123456   | Club Member   |
+  | name            | email                    | password | membership    | confirmed_at             |
+  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   | 2013-02-02 01:00:00 UTC  |
+  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator | 2013-02-02 01:00:00 UTC  |
+  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         | 2013-02-02 01:00:00 UTC  |
+  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       | 2013-02-02 01:00:00 UTC  |
+  | Jason Yang      | jason@gmail.com          | 123456   | Club Member   | 2013-02-02 01:00:00 UTC  |
   
  Given the following calendars exist:
   | name                       | UserId  | OtherId | start_time          | end_time            |

--- a/features/delete_availability.feature
+++ b/features/delete_availability.feature
@@ -6,8 +6,9 @@ Feature: Delete availability as a coach
 
 Background: Users in the Database
  Given the following users exist:
-  | id | name            | email                    | password | membership    |
-  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Coach         |
+  | id | name            | email                    | password | membership    | confirmed_at |
+  | 6  | Pizza           | pizza@gmail.com       | 12345678 | Coach         | 2013-02-02 01:00:00 UTC |
+  
 And the following availabilities exist:
   | coach_id     | day      | start_time    | end_time  |
   | 6            | Sunday   | 9am           | 12pm      |

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -7,11 +7,11 @@ Feature: Log in to different types of accounts
 Background: Users in the Database
 
  Given the following users exist:
-  | name            | email                    | password | membership    |
-  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   |
-  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator |
-  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         |
-  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       |
+  | name            | email                    | password | membership    | confirmed_at             |
+  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   | 2013-02-02 01:00:00 UTC  |
+  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator | 2013-02-02 01:00:00 UTC  |
+  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         | 2013-02-02 01:00:00 UTC  |
+  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       | 2013-02-02 01:00:00 UTC  |
 And I go to Login page
 
 

--- a/features/manager_elevate.feature
+++ b/features/manager_elevate.feature
@@ -7,11 +7,11 @@ Feature: (D)elevate other users as Manager
 Background: Users in the Database
 
  Given the following users exist:
-  | name            | email                    | password | membership    |
-  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   |
-  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator |
-  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         |
-  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       |
+  | name            | email                    | password | membership    | confirmed_at             |
+  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   | 2013-02-02 01:00:00 UTC  |
+  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator | 2013-02-02 01:00:00 UTC  |
+  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         | 2013-02-02 01:00:00 UTC  |
+  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       | 2013-02-02 01:00:00 UTC  |
 
 And I go to Login page
 

--- a/features/membership_history.feature
+++ b/features/membership_history.feature
@@ -7,11 +7,11 @@ Feature: Admin can see all membership changes
 Background: Users in the Database
 
  Given the following users exist:
-  | name            | email                    | password | membership    |
-  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   |
-  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator |
-  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         |
-  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       |
+  | name            | email                    | password | membership    | confirmed_at             |
+  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   | 2013-02-02 01:00:00 UTC  |
+  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator | 2013-02-02 01:00:00 UTC  |
+  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         | 2013-02-02 01:00:00 UTC  |
+  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       | 2013-02-02 01:00:00 UTC  |
 
 And I go to Login page
 

--- a/features/payment.feature
+++ b/features/payment.feature
@@ -7,11 +7,11 @@ Feature: Purchase Credits as a Club Member
 Background: Users in the Database
 
  Given the following users exist:
-  | name            | email                    | password | membership    |
-  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   |
-  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator |
-  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         |
-  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       |
+  | name            | email                    | password | membership    | confirmed_at             |
+  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   | 2013-02-02 01:00:00 UTC  |
+  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator | 2013-02-02 01:00:00 UTC  |
+  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         | 2013-02-02 01:00:00 UTC  |
+  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       | 2013-02-02 01:00:00 UTC  |
 
 And I go to Login page
 

--- a/features/profile_page.feature
+++ b/features/profile_page.feature
@@ -7,11 +7,11 @@ Feature: View Profile Pages
 Background: Users in the Database
 
  Given the following users exist:
-  | name            | email                    | password | membership    |
-  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   |
-  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator |
-  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         |
-  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       |
+  | name            | email                    | password | membership    | confirmed_at             |
+  | Joe Chen        | chenjoe@gmail.com        | 88888888 | Club Member   | 2013-02-02 01:00:00 UTC  |
+  | Matthew Sie     | matthew.sie@berkeley.edu | dabaka22 | Administrator | 2013-02-02 01:00:00 UTC  |
+  | Roger Destroyer | rogerahh@gmail.com       | 12345678 | Coach         | 2013-02-02 01:00:00 UTC  |
+  | John Doe        | johndoe@gmail.com        | 12345678 | Manager       | 2013-02-02 01:00:00 UTC  |
 And I go to Login page
 
 

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,8 +1,8 @@
 ### UTILITY METHODS ###
 
-def create_visitor(name="Joe Chen", email="chenjoe@gmail.com", password="88888888", password_confirmation="88888888", membership="Club Member")
+def create_visitor(name="Joe Chen", email="chenjoe@gmail.com", password="88888888", password_confirmation="88888888", membership="Club Member", confirmed_at=Time.now.utc)
     @visitor ||= { :name => name, :email => email,
-    :password => password, :password_confirmation => password_confirmation, :membership => membership }
+    :password => password, :password_confirmation => password_confirmation, :membership => membership, :confirmed_at => confirmed_at}
 end
   
 def find_user
@@ -17,8 +17,8 @@ def create_unconfirmed_user
 end
 
 
-def create_user(name="Joe Chen", email="chenjoe@gmail.com", password="88888888", password_confirmation="88888888", membership="Club Member")
-    create_visitor(name, email, password, password_confirmation, membership)
+def create_user(name="Joe Chen", email="chenjoe@gmail.com", password="88888888", password_confirmation="88888888", membership="Club Member", confirmed_at=Time.now.utc)
+    create_visitor(name, email, password, password_confirmation, membership, confirmed_at)
     delete_user
     @user = FactoryBot.create(:user, @visitor)
 end
@@ -72,7 +72,7 @@ end
 ### WHEN ###
 When /^I sign in with valid credentials with "(.*)" account with password: "(.*)"$/ do |name, password|
     user = User.find_by_name(name)
-    create_visitor(user.name, user.email, password, password, user.membership)
+    create_visitor(user.name, user.email, password, password, user.membership, user.confirmed_at)
     sign_in
 end
 

--- a/test/mailers/previews/auth_mailer_preview.rb
+++ b/test/mailers/previews/auth_mailer_preview.rb
@@ -1,0 +1,16 @@
+class MyMailerPreview < ActionMailer::Preview
+
+  def confirmation_instructions
+    @a = User.first
+    @a.unconfirmed_email = 'a@email.com'
+    AuthMailer.confirmation_instructions(@a, "faketoken", {})
+  end
+
+#   def reset_password_instructions
+#     MyMailer.reset_password_instructions(User.first, "faketoken", {})
+#   end
+
+#   def unlock_instructions
+#     MyMailer.unlock_instructions(User.first, "faketoken", {})
+#   end
+end


### PR DESCRIPTION
Implemented feature for email verification. This occurs in two different contexts: one for new users and one for existing users. For new users, their email must be verified before they are able to login. Upon signing up, they will receive an email with a confirmation link. Once that is clicked, there email will be verified, and they will be able to login. For existing users, the same process will happen anytime they update their account email. Until they verify their new email, they may only use the old email to login. Once the new email is verified, the old email will not work anymore, and the user can only login with the new email.